### PR TITLE
docs: warn against installing from PyPI

### DIFF
--- a/prepare.md
+++ b/prepare.md
@@ -32,9 +32,9 @@ A book is generated as a standalone HTML page by default, but can optionally be 
 * Spinning up a server
 
 ## Installing
-The best thing to do is install with pip: `pip install readalongs`.
+To install the latest version published to PyPI, you can run a standard pip installation: `pip install readalongs`. Be warned, however, that this project is currectly very active so the published versino is out-of-date. It's probably best to install the current development version.
 
-Otherwise, clone the repo and pip install it locally.
+To install the current development version, clone the repo and pip install it locally:
 
 ```
 $ git clone https://github.com/ReadAlongs/Studio.git

--- a/prepare.md
+++ b/prepare.md
@@ -32,7 +32,7 @@ A book is generated as a standalone HTML page by default, but can optionally be 
 * Spinning up a server
 
 ## Installing
-To install the latest version published to PyPI, you can run a standard pip installation: `pip install readalongs`. Be warned, however, that this project is currectly very active so the published versino is out-of-date. It's probably best to install the current development version.
+To install the latest version published to PyPI, you can run a standard pip installation: `pip install readalongs`. Be warned, however, that this project is currectly very active so the published version is out-of-date. It's probably best to install the current development version instead.
 
 To install the current development version, clone the repo and pip install it locally:
 


### PR DESCRIPTION
The published version on PyPI is quite out of date, and that will remain a problem as long as we're in active development, so let's make that clear in the instructions.